### PR TITLE
fix: 'Spoqa Han Sans' not working with firefox

### DIFF
--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -108,7 +108,7 @@ section, h2, p {
 .subtitle-text {
   width: 588px;
   height: 104px;
-  font-family: SpoqaHanSans;
+  font-family: 'Spoqa Han Sans';
   font-size: 32px;
   font-weight: normal;
   font-style: normal;
@@ -171,11 +171,11 @@ section, h2, p {
   color: #189bff;
 }
 .EXI-cardio .text-style-2 {
-  font-family: SpoqaHanSans;
+  font-family: 'Spoqa Han Sans';
 }
 
 .EXI-cardio-solution {
-  font-family: SpoqaHanSans;
+  font-family: 'Spoqa Han Sans';
   font-size: 54px;
   font-weight: bold;
   font-style: normal;
@@ -242,7 +242,7 @@ section, h2, p {
 .icon_text {
   margin-top: 60px;
   height: 84px;
-  font-family: SpoqaHanSans;
+  font-family: 'Spoqa Han Sans';
   font-size: 26px;
   font-weight: normal;
   font-style: normal;


### PR DESCRIPTION
Close #11 


SpoqaHanSans -> Spoqa Han Sans
으로 변경

css 에서 사용하는 font 명과
font-face 에서 지정한 front 명이 상이해서 생긴 일 입니다.
chrome 에서는 자동으로 변경해 매칭해주거 같습니다.
