### PR TITLE
fix: 랜딩 페이지에서 협력기관 폰트 및 배열 문제

### DIFF
--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -284,7 +284,7 @@ section, h2, p {
   margin-bottom: 90px;
   width: 95px;
   height: 38px;
-  font-family: SpoqaHanSans;
+  font-family: 'Spoqa Han Sans';
   font-size: 26px;
   font-weight: bold;
   font-style: normal;


### PR DESCRIPTION
1. font-family 명칭을 고쳐서 모든 브라우저에서 올바른 폰트 적용하도록 변경

closes: #17